### PR TITLE
Revert --with-deps until ubuntu upgrade is completed

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">=18.16.0"
   },
   "scripts": {
-    "configure": "yarn playwright install --with-deps",
+    "configure": "yarn playwright install",
     "test:ui": "npx playwright test --project chromium --headed",
     "test:fullfunctional": "npx playwright test --project chromium",
     "test:crossbrowser": "npx playwright test --project webkit --project firefox",


### PR DESCRIPTION
Ubuntu upgrade for Jenkins agents was reverted: https://hmcts-dts.slack.com/archives/CA4F2MAFR/p1740473735856259?thread_ts=1739954737.008509&cid=CA4F2MAFR hence removing `--with-deps` flag until this upgrade is completed (31st March expected)